### PR TITLE
Bug fix/verificar-telefono

### DIFF
--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -267,6 +267,24 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
             "href", reverse("clients_edit", kwargs={"id": client.id})
         )
 
+    def test_should_not_be_able_to_create_a_new_client_character_phone(self):
+        self.page.goto(f"{self.live_server_url}{reverse('clients_form')}")
+
+        expect(self.page.get_by_role("form")).to_be_visible()
+
+        self.page.get_by_label("Nombre").fill("NombrePersona")
+        self.page.get_by_label("Teléfono").fill("telefono")
+        self.page.get_by_label("Email").fill("email@vetsoft.com")
+        self.page.get_by_label("Ciudad").select_option("Berisso")
+
+        self.page.get_by_role("button", name="Guardar").click()
+
+        expect(self.page.get_by_text("NombrePersona")).not_to_be_visible()
+        expect(self.page.get_by_text("telefono")).not_to_be_visible()
+        expect(self.page.get_by_text("Por favor ingrese un teléfono")).to_be_visible()
+        expect(self.page.get_by_text("email@vetsoft.com")).not_to_be_visible()
+        expect(self.page.get_by_text("Berisso")).not_to_be_visible()
+
 
 class ClientsRepoTestCase(PlaywrightTestCase):
     def test_should_not_be_able_to_create_a_name(self):


### PR DESCRIPTION
Se agrega test e2e para que el formulario solo acepte caracteres numéricos en teléfono. 
Verifica que el campo no permita guardar si se pasan letras. 
Muestra como mensaje de error "Por favor ingrese un teléfono"